### PR TITLE
fix: case change logrus `Sirupsen` to `sirupsen`

### DIFF
--- a/httpTransport.go
+++ b/httpTransport.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/certifi/gocertifi"
 	"github.com/pkg/errors"
 )

--- a/httpTransport_test.go
+++ b/httpTransport_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 


### PR DESCRIPTION
### Introduction

Logrus repo path is now `github.com/sirupsen/logrus` and not `github.com/Sirupsen/logrus`.