### PR TITLE
Sentry 9 deprecated the priv key in the DSN

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -41,6 +41,11 @@ const (
 	// a valid public key contained within its URL
 	ErrMissingPublicKey = ErrType("sentry: missing public key")
 
+	// ErrMissingPrivateKey is returned when a DSN does not have
+	// a valid private key contained within its URL
+	// [DEPRECATED] error is never thrown since Sentry 9 has deprecated the secret key requirement
+	ErrMissingPrivateKey = ErrType("sentry: missing private key")
+
 	// ErrMissingProjectID is returned when a DSN does not have a valid
 	// project ID contained within its URL
 	ErrMissingProjectID = ErrType("sentry: missing project ID")

--- a/dsn.go
+++ b/dsn.go
@@ -41,10 +41,6 @@ const (
 	// a valid public key contained within its URL
 	ErrMissingPublicKey = ErrType("sentry: missing public key")
 
-	// ErrMissingPrivateKey is returned when a DSN does not have
-	// a valid private key contained within its URL
-	ErrMissingPrivateKey = ErrType("sentry: missing private key")
-
 	// ErrMissingProjectID is returned when a DSN does not have a valid
 	// project ID contained within its URL
 	ErrMissingProjectID = ErrType("sentry: missing project ID")
@@ -72,7 +68,7 @@ func (d *dsn) AuthHeader() string {
 	}
 
 	if d.PrivateKey == "" {
-		return ""
+		return fmt.Sprintf("Sentry sentry_version=4, sentry_key=%s", d.PublicKey)
 	}
 
 	return fmt.Sprintf("Sentry sentry_version=4, sentry_key=%s, sentry_secret=%s", d.PublicKey, d.PrivateKey)
@@ -95,10 +91,9 @@ func (d *dsn) Parse(dsn string) error {
 	d.PublicKey = uri.User.Username()
 
 	privateKey, ok := uri.User.Password()
-	if !ok {
-		return errors.Wrap(fmt.Errorf("missing URL password"), ErrMissingPrivateKey.Error())
+	if ok {
+		d.PrivateKey = privateKey
 	}
-	d.PrivateKey = privateKey
 
 	uri.User = nil
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -30,7 +30,7 @@ func TestDSN(t *testing.T) {
 				{"With a valid URL", "https://u:p@example.com/sentry/1", nil},
 				{"With a badly formatted URL", ":", ErrBadURL},
 				{"Without a public key", "https://example.com/sentry/1", ErrMissingPublicKey},
-				{"Without a private key", "https://u@example.com/sentry/1", ErrMissingPrivateKey},
+				{"Without a private key", "https://u@example.com/sentry/1", nil},
 				{"Without a project ID", "https://u:p@example.com", ErrMissingProjectID},
 			}
 
@@ -60,7 +60,7 @@ func TestDSN(t *testing.T) {
 				d := &dsn{
 					PublicKey: "key",
 				}
-				So(d.AuthHeader(), ShouldEqual, "")
+				So(d.AuthHeader(), ShouldEqual, "Sentry sentry_version=4, sentry_key=key")
 			})
 
 			Convey("With valid keys", func() {

--- a/httpTransport_test.go
+++ b/httpTransport_test.go
@@ -128,7 +128,8 @@ func TestHTTPTransport(t *testing.T) {
 
 			Convey("With a missing private key", func() {
 				err := t.Send("https://key@example.com/sentry/1", p)
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "got http status 404, expected 200")
 			})
 
 			Convey("When it cannot connect to the server", func() {

--- a/httpTransport_test.go
+++ b/httpTransport_test.go
@@ -128,8 +128,7 @@ func TestHTTPTransport(t *testing.T) {
 
 			Convey("With a missing private key", func() {
 				err := t.Send("https://key@example.com/sentry/1", p)
-				So(err, ShouldNotBeNil)
-				So(ErrMissingPrivateKey.IsInstance(err), ShouldBeTrue)
+				So(err, ShouldBeNil)
 			})
 
 			Convey("When it cannot connect to the server", func() {


### PR DESCRIPTION
### Introduction
*Give us a short description of what your pull request does*
> This PR removes the PrivateKey requirement in the DSN (from Sentry 9)