### PR TITLE
Fix some bugs in the breadcrumbs code

### DIFF
--- a/breadcrumbs.go
+++ b/breadcrumbs.go
@@ -79,10 +79,13 @@ func (l *breadcrumbsList) WithSize(length int) BreadcrumbsList {
 
 	l.MaxLength = length
 
-	for l.Length > l.MaxLength {
-		if l.Head == nil {
-			break
+	if length == 0 {
+		l.Head = nil
+		l.Tail = nil
+		l.Length = 0
 	}
+
+	for l.Length > l.MaxLength && l.Head != nil {
 		l.Head = l.Head.Next
 		l.Length--
 	}
@@ -147,10 +150,7 @@ func (l *breadcrumbsList) append(b Breadcrumb) {
 	l.Tail = n
 	l.Length++
 
-	for l.Length > l.MaxLength {
-		if l.Head == nil {
-			break
-		}
+	for l.Length > l.MaxLength && l.Head != nil {
 		l.Head = l.Head.Next
 		l.Length--
 	}

--- a/breadcrumbs.go
+++ b/breadcrumbs.go
@@ -66,7 +66,7 @@ type breadcrumbsList struct {
 	Head   *breadcrumbListNode
 	Tail   *breadcrumbListNode
 	Length int
-	mutex  sync.Mutex
+	mutex  sync.RWMutex
 }
 
 func (l *breadcrumbsList) Class() string {
@@ -82,7 +82,7 @@ func (l *breadcrumbsList) WithSize(length int) BreadcrumbsList {
 	for l.Length > l.MaxLength {
 		if l.Head == nil {
 			break
-		}
+	}
 		l.Head = l.Head.Next
 		l.Length--
 	}
@@ -157,6 +157,9 @@ func (l *breadcrumbsList) append(b Breadcrumb) {
 }
 
 func (l *breadcrumbsList) list() []Breadcrumb {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+
 	current := l.Head
 	out := []Breadcrumb{}
 	for current != nil {

--- a/breadcrumbs_test.go
+++ b/breadcrumbs_test.go
@@ -214,6 +214,21 @@ func TestBreadcrumbs(t *testing.T) {
 						"index": 2,
 					})
 				})
+
+				Convey("Should empty the list if the size is set to 0", func() {
+					var b Breadcrumb
+					for i := 0; i < 3; i++ {
+						b = l.NewDefault(map[string]interface{}{
+							"index": i,
+						})
+						So(b, ShouldNotBeNil)
+					}
+
+					l.WithSize(0).WithSize(3)
+					So(ll.Length, ShouldEqual, 0)
+					So(ll.Head, ShouldBeNil)
+					So(ll.Tail, ShouldBeNil)
+				})
 			})
 
 			Convey("append()", func() {


### PR DESCRIPTION
### Introduction
This PR fixes a race condition when serializing breadcrumbs as well as an issue when using `.WithSize(0)` to clear the breadcrumbs buffer.

### Contains
*Tell us what your pull request includes*

- [ ] :radioactive: Breaking API changes
- [ ] :star: Features
  - [ ] :star2: New features
  - [x] :beetle: Fixes for existing features
  - [ ] :100: Automated tests for my changes
- [ ] :books: Documentation
  - [ ] :memo: New documentation
  - [ ] :bookmark_tabs: Fixes for existing documentation
- [ ] :electric_plug: Plugins
  - [ ] :star2: New plugins
  - [ ] :beetle: Fixes for existing plugins
  - [ ] :100: Automated tests for my changes

### Description
This PR is a back-port of some work from #7 which identified issues in the breadcrumb implementation which could lead to data inconsistencies and undefined behaviour.
